### PR TITLE
Fixing properties with dynamic names

### DIFF
--- a/phply/pythonast.py
+++ b/phply/pythonast.py
@@ -170,6 +170,14 @@ def from_phpast(node):
                                         **pos(node)),
                            [from_phpast(node.expr)],
                            [], None, None, **pos(node))
+        if (isinstance(node.node, php.ObjectProperty)
+            and isinstance(node.node.name, php.BinaryOp)):
+            return to_stmt(py.Call(py.Name('setattr', py.Load(**pos(node)),
+                                   **pos(node)),
+                           [from_phpast(node.node.node),
+                            from_phpast(node.node.name),
+                            from_phpast(node.expr)],
+                           [], None, None, **pos(node)))
         return py.Assign([store(from_phpast(node.node))],
                          from_phpast(node.expr),
                          **pos(node))


### PR DESCRIPTION
Hi ramen,

This patch fixes a tiny bug that raised an exception when attempting to translate the following PHP code into Python, because of the property names being forged from string concatenation:

```
<?php
class Obj {
}
$obj = new Obj();
$foo = 'foo';
$obj->{$foo.'bar'} = 'baz';
print $obj->{"{$foo}bar"} . "\n";
?>
```

Also, assignment to this kind of dynamically named property is handled with setattr in Python:

```
class Obj(object, ):
    pass
obj = Obj()
foo = 'foo'
setattr(obj, ('%sbar' % (foo,)), 'baz')
print ('%s\n' % (getattr(obj, ('%sbar' % (foo,))),))
```

Hope you'll find it usefull!

Cheers,
Yoann
