### PR TITLE
Allow invalid \x escape sequences

### DIFF
--- a/phply/phpparse.py
+++ b/phply/phpparse.py
@@ -1256,11 +1256,14 @@ def p_encaps_list(p):
 
 def p_encaps_list_string(p):
     'encaps_list : encaps_list ENCAPSED_AND_WHITESPACE'
+    try:
+        p2 = p[2].decode('string_escape')
+    except ValueError:
+        p2 = p[2]
     if p[1] == '':
-        p[0] = p[2].decode('string_escape')
+        p[0] = p2
     else:
-        p[0] = ast.BinaryOp('.', p[1], p[2].decode('string_escape'),
-                            lineno=p.lineno(2))
+        p[0] = ast.BinaryOp('.', p[1], p2, lineno=p.lineno(2))
 
 def p_encaps_var(p):
     'encaps_var : VARIABLE'

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -137,10 +137,12 @@ def test_string_unescape():
     input = r"""<?
         '\r\n\t\\\'';
         "\r\n\t\\\"";
+        "\x97\x[0-9]";
     ?>"""
     expected = [
         r"\r\n\t\'",
         "\r\n\t\\\"",
+        r"\x97\x[0-9]",
     ]
     eq_ast(input, expected)
 


### PR DESCRIPTION
`"\xHELLO"` is a valid string in PHP, while `decode('string_escape')`
will simply fail with a `ValueError` on it. These should be let through
as is without raising an exception.
