### PR TITLE
Fix support for array typehinting

### DIFF
--- a/phply/phpparse.py
+++ b/phply/phpparse.py
@@ -1237,7 +1237,8 @@ def p_static_non_empty_array_pair_list_pair(p):
 
 def p_namespace_name(p):
     '''namespace_name : namespace_name NS_SEPARATOR STRING
-                      | STRING'''
+                      | STRING
+                      | ARRAY'''
     if len(p) == 4:
         p[0] = p[1] + p[2] + p[3]
     else:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -700,7 +700,7 @@ def test_magic_constants():
 
 def test_type_hinting():
     input = r"""<?
-    function foo(Foo $var1, Bar $var2=1, Quux &$var3, Corge &$var4=1) {
+    function foo(Foo $var1, Bar $var2=1, Quux &$var3, Corge &$var4=1, array &$var5=array()) {
     }
     ?>""";
     expected = [
@@ -708,7 +708,8 @@ def test_type_hinting():
             [FormalParameter('$var1', None, False, 'Foo'),
              FormalParameter('$var2', 1, False, 'Bar'),
              FormalParameter('$var3', None, True, 'Quux'),
-             FormalParameter('$var4', 1, True, 'Corge')],
+             FormalParameter('$var4', 1, True, 'Corge'),
+             FormalParameter('$var5', Array([]), True, 'array')],
             [],
             False)]
     eq_ast(input, expected)


### PR DESCRIPTION
`function(array $a) {}` typehinting would not work as `ARRAY` is a
reserved token of its own and gets precedence over `STRING` in
`namespace_name`, resulting in a syntax error. By adding `ARRAY` as a
variant a successful parse is attained. Tests included.
