### PR TITLE
Fix class constants as static scalars

### DIFF
--- a/phply/phpparse.py
+++ b/phply/phpparse.py
@@ -1182,6 +1182,7 @@ def p_common_scalar_magic_ns(p):
 
 def p_static_scalar(p):
     '''static_scalar : common_scalar
+                     | class_constant
                      | QUOTE QUOTE
                      | QUOTE ENCAPSED_AND_WHITESPACE QUOTE'''
     if len(p) == 2:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -713,3 +713,13 @@ def test_type_hinting():
             False)]
     eq_ast(input, expected)
 
+def test_static_scalar_class_constants():
+    input = r"""<?
+    class A { public $b = self::C; function d($var1=self::C) {} }
+    ?>"""
+    expected = [
+		Class('A', None, None, [],
+			[ClassVariables(['public'], [ClassVariable('$b', StaticProperty('self', 'C'))]),
+			 Method('d', [], [FormalParameter('$var1', StaticProperty('self', 'C'), False, None)], [], False)
+			])]
+    eq_ast(input, expected)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -718,8 +718,8 @@ def test_static_scalar_class_constants():
     class A { public $b = self::C; function d($var1=self::C) {} }
     ?>"""
     expected = [
-		Class('A', None, None, [],
-			[ClassVariables(['public'], [ClassVariable('$b', StaticProperty('self', 'C'))]),
-			 Method('d', [], [FormalParameter('$var1', StaticProperty('self', 'C'), False, None)], [], False)
-			])]
+        Class('A', None, None, [],
+            [ClassVariables(['public'], [ClassVariable('$b', StaticProperty('self', 'C'))]),
+             Method('d', [], [FormalParameter('$var1', StaticProperty('self', 'C'), False, None)], [], False)
+            ])]
     eq_ast(input, expected)


### PR DESCRIPTION
All class constants are valid static scalars in PHP, this goes for
variable initialization, function parameter defaults, etc.
Added `class_constant` as a valid `static_scalar` variant.
