### PR TITLE
Implement backtick support

### DIFF
--- a/phply/phpparse.py
+++ b/phply/phpparse.py
@@ -761,6 +761,10 @@ def p_function_call_variable(p):
     'function_call : variable_without_objects LPAREN function_call_parameter_list RPAREN'
     p[0] = ast.FunctionCall(p[1], p[3], lineno=p.lineno(2))
 
+def p_function_call_backtick_shell_exec(p):
+    'function_call : BACKTICK encaps_list BACKTICK'
+    p[0] = ast.FunctionCall('shell_exec', [ast.Parameter(p[2], False)], lineno=p.lineno(1))
+
 def p_method_or_not(p):
     '''method_or_not : LPAREN function_call_parameter_list RPAREN
                      | empty'''

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -346,3 +346,20 @@ def test_punctuation():
         ('AT', '@'),
     ]
     eq_tokens(input, expected)
+
+def test_backticks():
+    input = '<? `ls $one`; "`o``ne`"; \'`one`\'; ?>'
+    expected = [
+        ('BACKTICK', '`'),
+        ('ENCAPSED_AND_WHITESPACE', 'ls '),
+        ('VARIABLE', '$one'),
+        ('BACKTICK', '`'),
+        ('SEMI', ';'),
+        ('QUOTE', '"'),
+        ('ENCAPSED_AND_WHITESPACE', '`o``ne`'),
+        ('QUOTE', '"'),
+        ('SEMI', ';'),
+        ('CONSTANT_ENCAPSED_STRING', "'`one`'"),
+        ('SEMI', ';'),
+    ]
+    eq_tokens(input, expected)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -713,3 +713,13 @@ def test_type_hinting():
             False)]
     eq_ast(input, expected)
 
+def test_backtick_shell_exec():
+    input = '<? `$cmd` . `date`; `echo $line`; ?>'
+    expected = [
+        BinaryOp('.',
+            FunctionCall('shell_exec', [Parameter(Variable('$cmd'), False)]),
+            FunctionCall('shell_exec', [Parameter('date', False)])
+        ),
+        FunctionCall('shell_exec', [Parameter(BinaryOp('.', 'echo ', Variable('$line')), False)])
+    ]
+    eq_ast(input, expected)


### PR DESCRIPTION
Backticks now resolve to a `shell_exec` function call. Tests included.
