### PR TITLE
Fix `?><?php` interpretation

### DIFF
--- a/phply/phplex.py
+++ b/phply/phplex.py
@@ -453,6 +453,11 @@ class FilteredLexer(object):
 
             # Skip over open tags, but keep track of when we see them.
             if t.type == 'OPEN_TAG':
+                if self.last_token and self.last_token.type == 'SEMI':
+                    # Rewrite ?><?php as a semicolon.
+                    t.type = 'SEMI'
+                    t.value = ';'
+                    break
                 self.last_token = t
                 t = self.lexer.token()
                 continue

--- a/tests/test_filtered_lexer.py
+++ b/tests/test_filtered_lexer.py
@@ -1,0 +1,52 @@
+from phply import phplex
+
+import nose.tools
+import pprint
+
+def eq_tokens(input, expected, ignore=('WHITESPACE', 'OPEN_TAG', 'CLOSE_TAG')):
+    output = []
+    lexer = phplex.lexer.clone()
+    lexer.input(input)
+
+    while True:
+        tok = lexer.token()
+        if not tok: break
+        if tok.type in ignore: continue
+        output.append((tok.type, tok.value))
+
+    print 'Lexer output:'
+    pprint.pprint(output)
+    print
+
+    print 'Token by token:'
+    for out, exp in zip(output, expected):
+        print '\tgot:', out, '\texpected:', exp
+        nose.tools.eq_(out, exp)
+
+    assert len(output) == len(expected), \
+           'output length was %d, expected %s' % (len(output), len(expected))
+
+def test_close_open_tags():
+    # ?><?php should be interpreted as a semi-colon
+    input = '<?php if (1): if (2) 3; ?><?php else: 0; endif;'
+    expected = [
+        ('IF', 'if'),
+        ('LPAREN', '('),
+        ('LNUMBER', '1'),
+        ('RPAREN', ')'),
+        ('COLON', ':'),
+        ('IF', 'if'),
+        ('LPAREN', '('),
+        ('LNUMBER', '2'),
+        ('RPAREN', ')'),
+        ('LNUMBER', '3'),
+        ('SEMI', ';'),
+        ('SEMI', ';'),
+        ('ELSE', 'else'),
+        ('COLON', ':'),
+        ('LNUMBER', '0'),
+        ('SEMI', ';'),
+        ('ENDIF', 'endif'),
+        ('SEMI', ';')
+    ]
+    eq_tokens(input, expected)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -713,3 +713,10 @@ def test_type_hinting():
             False)]
     eq_ast(input, expected)
 
+def test_open_close_tags_ignore():
+    # The filtered lexer should correctly interpret ?><?
+    input = '<? if (1): if (2) 3; ?><? else: 0; endif;'
+    expected = [
+        If(1, Block([If(2, 3, [], None), None]), [], Else(Block([0])))
+    ]
+    eq_ast(input, expected)


### PR DESCRIPTION
?><?php used to break inside the FilteredLexer due to closing tag
ignores and other issues, resulting in syntax errors. Rewriting
?><?php with ; fixes this issue.

Examples of valid code:
- `if (1): if (2) 3; ?><?php else: 0; endif;`
- `if (1): if (2) 3; ; else: 0; endif;`

Invalid code:
- `if (1): if (2) 3; else: 0; endif;` (note the missing ; before else:)
