### PR TITLE
Add shorthand ternary operator support

### DIFF
--- a/phply/phpparse.py
+++ b/phply/phpparse.py
@@ -1006,6 +1006,10 @@ def p_expr_ternary_op(p):
     'expr : expr QUESTION expr COLON expr'
     p[0] = ast.TernaryOp(p[1], p[3], p[5], lineno=p.lineno(2))
 
+def p_expr_short_ternary_op(p):
+    'expr : expr QUESTION COLON expr'
+    p[0] = ast.TernaryOp(p[1], p[1], p[4], lineno=p.lineno(2))
+
 def p_expr_pre_incdec(p):
     '''expr : INC variable
             | DEC variable'''

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -713,3 +713,10 @@ def test_type_hinting():
             False)]
     eq_ast(input, expected)
 
+def test_ternary():
+    input = '<? 1 ? 2 : 3; 4 ? : 5;'
+    expected = [
+        TernaryOp(1, 2, 3),
+        TernaryOp(4, 4, 5),
+    ]
+    eq_ast(input, expected)


### PR DESCRIPTION
`$condition ? : $else` format has been supported since PHP 5.3 (2009),
let's get this in.

Conflicts:
    tests/test_parser.py
