### PR TITLE
Support CRLF in HEREDOC_START

### DIFF
--- a/phply/phplex.py
+++ b/phply/phplex.py
@@ -366,7 +366,7 @@ def t_property_STRING(t):
 # Heredocs
 
 def t_php_START_HEREDOC(t):
-    r'<<<[ \t]*(?P<label>[A-Za-z_][\w_]*)\n'
+    r'<<<[ \t]*(?P<label>[A-Za-z_][\w_]*)\r?\n'
     t.lexer.lineno += t.value.count("\n")
     t.lexer.push_state('heredoc')
     t.lexer.heredoc_label = t.lexer.lexmatch.group('label')


### PR DESCRIPTION
HEREDOC was not parsed correctly on data with Windows line endings.
