### PR TITLE
Ensure parsetab is generated at install time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,14 @@ from __future__ import unicode_literals
 
 from setuptools import setup, find_packages
 
+try:
+    from phply.phpparse import make_parser
+    # Ensure the parser tab is generated
+    make_parser()
+except ImportError:
+    # ply is not installed
+    pass
+
 setup(name="phply",
       version="1.0.0",
       packages=find_packages(),


### PR DESCRIPTION
This way it is available even on global installation.

Fixes #32